### PR TITLE
Changed kabob-base version to 0.2 in human ice rdf gen script

### DIFF
--- a/scripts/human-ice-rdf-gen.sh
+++ b/scripts/human-ice-rdf-gen.sh
@@ -31,7 +31,7 @@ COUNTER=1
 for ds in "${DATASOURCES[@]}"
 do
     echo "Starting kabob-base container to process: $ds"
-    DID=$DID" "`docker run -d --name "rdf_gen_$COUNTER" --volumes-from kabob_data billbaumgartner/kabob-base:0.1 ./ice-rdf-gen.sh "$TAX" "$ds" "$COUNTER"`
+    DID=$DID" "`docker run -d --name "rdf_gen_$COUNTER" --volumes-from kabob_data billbaumgartner/kabob-base:0.2 ./ice-rdf-gen.sh "$TAX" "$ds" "$COUNTER"`
     COUNTER=$((COUNTER + 1))
 done
 docker wait $DID


### PR DESCRIPTION
This is a bug fix. The version should be 0.2 to match the version in the step1_rdf-gen.sh script.